### PR TITLE
Leetcode 1683 (Easy): Invalid Tweets

### DIFF
--- a/sql/lc1683e_invalid_tweets.sql
+++ b/sql/lc1683e_invalid_tweets.sql
@@ -1,0 +1,48 @@
+"""
+Leetcode 1683 (Easy): Invalid Tweets
+
+Table: Tweets
++----------------+---------+
+| Column Name    | Type    |
++----------------+---------+
+| tweet_id       | int     |
+| content        | varchar |
++----------------+---------+
+tweet_id is the primary key for this table.
+This table contains all the tweets in a social media app.
+
+Write an SQL query to find the IDs of the invalid tweets.
+The tweet is invalid if the number of characters used in the content of the tweet is strictly greater than 15.
+Return the result table in any order.
+The query result format is in the following example.
+
+Example 1:
+Input:
+Tweets table:
++----------+----------------------------------+
+| tweet_id | content                          |
++----------+----------------------------------+
+| 1        | Vote for Biden                   |
+| 2        | Let us make America great again! |
++----------+----------------------------------+
+Output:
++----------+
+| tweet_id |
++----------+
+| 2        |
++----------+
+Explanation:
+Tweet 1 has length = 14. It is a valid tweet.
+Tweet 2 has length = 32. It is an invalid tweet.
+"""
+
+-- Write an SQL query to find the IDs of the invalid tweets.
+-- The tweet is invalid if the number of characters used in the content of the tweet is strictly greater than 15.
+-- Return the result table in any order.
+
+SELECT
+  t.tweet_id
+FROM
+  Tweets t
+WHERE
+  LENGTH(t.content) > 15


### PR DESCRIPTION
@@ -0,0 +1,48 @@
"""
Leetcode 1683 (Easy): Invalid Tweets
Table: Tweets
+----------------+---------+
| Column Name    | Type    |
+----------------+---------+
| tweet_id       | int     |
| content        | varchar |
+----------------+---------+
tweet_id is the primary key for this table.
This table contains all the tweets in a social media app.
Write an SQL query to find the IDs of the invalid tweets.
The tweet is invalid if the number of characters used in the content of the tweet is strictly greater than 15.
Return the result table in any order.
The query result format is in the following example.
Example 1:
Input:
Tweets table:
+----------+----------------------------------+
| tweet_id | content                          |
+----------+----------------------------------+
| 1        | Vote for Biden                   |
| 2        | Let us make America great again! |
+----------+----------------------------------+
Output:
+----------+
| tweet_id |
+----------+
| 2        |
+----------+
Explanation:
Tweet 1 has length = 14. It is a valid tweet.
Tweet 2 has length = 32. It is an invalid tweet.
"""

